### PR TITLE
Add the missing "System" category required by FDO menu specification

### DIFF
--- a/misc/evilvte.desktop
+++ b/misc/evilvte.desktop
@@ -38,4 +38,4 @@ Comment[vi]=Trình giả lập Terminal
 Comment[zh_TW]=終端機程式
 Icon=evilvte
 Exec=evilvte
-Categories=Utility;TerminalEmulator;
+Categories=System;Utility;TerminalEmulator;


### PR DESCRIPTION
Just run "desktop-file-validate evilvte.desktop" and see the warning message if this commit is not present. Also see http://standards.freedesktop.org/menu-spec/latest/apa.html .

Actually, I think the better fix is just only using the "System" catetory and remove the "Utilitiy" category. That avoids the duplicated entries in both menus/categories. And that is exactly what xterm is doing. I will leave the removing thing for the maintainer to decide.
