### PR TITLE
Fixed assert error with zsh

### DIFF
--- a/src/evilvte.c
+++ b/src/evilvte.c
@@ -3354,7 +3354,7 @@ static void switch_page(void)
   }
 #endif
 #if WINDOW_TITLE_DYNAMIC
-  gtk_window_set_title(GTK_WINDOW(main_window), vte_terminal_get_window_title(VTE_TERMINAL(term->vte)));
+  gtk_window_set_title(GTK_WINDOW(main_window), vte_terminal_get_window_title(VTE_TERMINAL(term->vte))?:VTE_PROGRAM_NAME);
 #endif
 }
 


### PR DESCRIPTION
with my zsh config I got the following error when I opened a new tab
Gdk-CRITICAL **: IA__gdk_window_set_title: assertion `title != NULL' failed

I added a check for NULL in void switch_page(void).
